### PR TITLE
Force all icons to be grayscale.

### DIFF
--- a/dist/main.css
+++ b/dist/main.css
@@ -86,6 +86,13 @@ section#zazu div.results ul li.active {
   background-color: #343a40;
   color: #f8f9fa;
 }
+section#zazu div.results ul li img.icon {
+  -webkit-filter: opacity(30%) grayscale(100%);
+}
+section#zazu div.results ul li.active img.icon,
+section#zazu div.results ul li:hover img.icon {
+  -webkit-filter: opacity(100%) grayscale(100%);
+}
 section#zazu div.results ul li:hover {
   background-color: #495057;
   color: #e9ecef;


### PR DESCRIPTION
This makes it so image icons are also grayscale, instead of just the font-awesome icons.

![screen shot 2017-01-10 at 11 45 01 am](https://cloud.githubusercontent.com/assets/769039/21821990/608f36b8-d72a-11e6-96b3-0a4b9072dc4e.png)